### PR TITLE
replace default HTTP server mux

### DIFF
--- a/pollen.go
+++ b/pollen.go
@@ -141,13 +141,14 @@ func main() {
 		tracker = NewTracker()
 	}
 	handler := &PollenServer{randomSource: dev, log: log, readSize: *size, tracker: tracker}
-	http.Handle("/", handler)
+	mux := http.NewServeMux()
+	mux.Handle("/", handler)
 	var httpListeners sync.WaitGroup
 	if *httpPort != "" {
 		httpAddr := fmt.Sprintf(":%s", *httpPort)
 		httpListeners.Add(1)
 		go func() {
-			handler.fatal(http.ListenAndServe(httpAddr, nil))
+			handler.fatal(http.ListenAndServe(httpAddr, mux))
 			httpListeners.Done()
 		}()
 	}

--- a/pollen_test.go
+++ b/pollen_test.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"testing"
-	"time"
 )
 
 type logEntry struct {
@@ -364,33 +363,4 @@ func TestReadFailure(t *testing.T) {
 	s.Assert(s.logger.logs[1].severity == "err" &&
 		s.logger.logs[1].message[:len(start)] == start,
 		"didn't get the expected error message, got:", s.logger.logs[1])
-}
-
-// TestNoDebugVars tests that pollen doesn't expose the /debug/vars endpoint
-func TestNoDebugVars(t *testing.T) {
-	originalArgs := os.Args
-	defer func() { os.Args = originalArgs }()
-	os.Args = []string{"pollen", "--http-port=28434", "--https-port=", "--metrics-port=32112"}
-	go main()
-	var resp *http.Response
-	var err error
-	deadline := time.Now().Add(3 * time.Second)
-	for {
-		resp, err = http.Get("http://127.0.0.1:28434/debug/vars")
-		if err == nil || time.Now().After(deadline) {
-			break
-		} else {
-			time.Sleep(250 * time.Millisecond)
-		}
-	}
-	if err != nil {
-		t.Fatalf("failed to connect to the test server: %s", err)
-	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("failed to connect to the test server: %s", err)
-	}
-	if string(body) != usePollinateError+"\n" {
-		t.Fatalf("/debug/vars is exposed, content: %s", string(body))
-	}
 }

--- a/pollen_test.go
+++ b/pollen_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"time"
 )
 
 type logEntry struct {
@@ -363,4 +364,33 @@ func TestReadFailure(t *testing.T) {
 	s.Assert(s.logger.logs[1].severity == "err" &&
 		s.logger.logs[1].message[:len(start)] == start,
 		"didn't get the expected error message, got:", s.logger.logs[1])
+}
+
+// TestNoDebugVars tests that pollen doesn't expose the /debug/vars endpoint
+func TestNoDebugVars(t *testing.T) {
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+	os.Args = []string{"pollen", "--http-port=28434", "--https-port=", "--metrics-port=32112"}
+	go main()
+	var resp *http.Response
+	var err error
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		resp, err = http.Get("http://127.0.0.1:28434/debug/vars")
+		if err == nil || time.Now().After(deadline) {
+			break
+		} else {
+			time.Sleep(250 * time.Millisecond)
+		}
+	}
+	if err != nil {
+		t.Fatalf("failed to connect to the test server: %s", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to connect to the test server: %s", err)
+	}
+	if string(body) != usePollinateError+"\n" {
+		t.Fatalf("/debug/vars is exposed, content: %s", string(body))
+	}
 }


### PR DESCRIPTION
Previously, pollen uses the default http server mux which exposed `expvar` information at the `/debug/vars` endpoint. This update fixes the issue by using a non-default http server mux for http endpoint instead.

To reproduce, run:
```bash
go run pollen --http-port=8080 --https-port= --metrics-port=2112 &
curl http://localhost:8080/debug/vars
```