### PR TITLE
Add /health endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ GO_TEST=go test
 GO_CLEAN=go clean
 GIT_ARCHIVE=git archive
 
-VERSION=4.22
-TAG=v4.22
+VERSION=4.23
+TAG=v4.23
 
 all: pollen
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pollen (4.23) UNRELEASED; urgency=low
+
+  * UNRELEASED
+
+ -- Weii Wang <weii.wang@canonical.com>  Thu, 22 May 2025 16:00:32 +0800
+
 pollen (4.22-0ubuntu1) oracular; urgency=medium
 
   * New upstream release 4.22

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: pollen
-version: 4.22
+version: 4.23
 summary: Pollen Entropy-as-a-Service web server
 description: >-
   Pollen is a high-performance, scalable, free web server that provides


### PR DESCRIPTION
Implement an /health endpoint on the pollen server to support external health monitoring. Under normal operation, the endpoint responds with HTTP 200 and body "OK".

Bump the pollen version to 4.23